### PR TITLE
refactor: replace event type strings with enum

### DIFF
--- a/lib/properties.dart
+++ b/lib/properties.dart
@@ -34,15 +34,6 @@ class Properties {
   /// Default bool evaluator instance
   BoolEvaluator _be = BoolEvaluator();
 
-  /// The property added event name
-  static const String ADD_PROPERTY_EVENTNAME = 'add';
-
-  /// The property updated event name
-  static const String UPDATE_PROPERTY_EVENTNAME = 'update';
-
-  /// The property deleted event name
-  static const String DELETE_PROPERTY_EVENTNAME = 'delete';
-
   /// Controller for Add events
   late final _addEventController = StreamController<AddEvent>.broadcast();
 
@@ -52,7 +43,7 @@ class Properties {
   /// Controller for ALL change events (adds, updates and deletes).
   ///
   /// NB: it seems an overkill to have a stream for each type of event. Consider replacing adds and updates with this one.
-  late final _changeController = StreamController<PropertiesEvent>.broadcast();
+  late final _changeController = StreamController<ChangeEvent>.broadcast();
 
   /// Create a new properties instance by naming the source file using [name].
   Properties(String name) {
@@ -463,7 +454,7 @@ class Properties {
   Stream<UpdateEvent> get onUpdate => _updateEventController.stream;
 
   /// Get the stream instance for the change event stream.
-  Stream<PropertiesEvent> get onChange => _changeController.stream;
+  Stream<ChangeEvent> get onChange => _changeController.stream;
 
   /// Getter for [boolEvaluator] instance.
   BoolEvaluator get boolEvaluator => this._be;

--- a/lib/src/properties_events.dart
+++ b/lib/src/properties_events.dart
@@ -1,27 +1,35 @@
 part of properties;
 
+/// All property related event types.
+enum EventType {
+  /// Property added event.
+  add,
+
+  /// Property updated event.
+  update,
+
+  /// Property deleted event.
+  delete,
+}
+
 /// A factory to create simple Properties' related events.
-///
-/// NB: please consider renaming to "ChangeEvent".
-class PropertiesEvent {
-  // NB: consider enums instead of strings
-  final String _eventType;
+class ChangeEvent {
+  final EventType _eventType;
 
   /// Create a new event instance by name the [eventType] only.
-  const PropertiesEvent(this._eventType);
+  const ChangeEvent(this._eventType);
 
   /// Getter fro the [eventType] of this event.
-  String get type => _eventType;
+  EventType get type => _eventType;
 }
 
 /// A factory to create simple property added event.
-class AddEvent extends PropertiesEvent {
+class AddEvent extends ChangeEvent {
   final String _key;
   final String _value;
 
   /// Create a new property added event instance by name the [eventType] and the property's [key] and [value].
-  const AddEvent(this._key, this._value)
-      : super(Properties.ADD_PROPERTY_EVENTNAME);
+  const AddEvent(this._key, this._value) : super(EventType.add);
 
   /// Getter for the added [key].
   String get key => _key;
@@ -30,45 +38,45 @@ class AddEvent extends PropertiesEvent {
   String get value => _value;
 
   String toString() {
-    return "${Properties.ADD_PROPERTY_EVENTNAME} on ${this._key}: ${this._value}";
+    return "${EventType.add} on ${this._key}: ${this._value}";
   }
 }
 
 /// A factory to create simple property added event.
-class UpdateEvent extends PropertiesEvent {
+class UpdateEvent extends ChangeEvent {
   final String _key;
-  final String? _oldvalue;
-  final String? _newvalue;
+  final String? _oldValue;
+  final String? _newValue;
 
   /// Create a new property updated event instance by name the [eventType] and the property's [key] and [value].
-  const UpdateEvent(this._key, this._newvalue, this._oldvalue)
-      : super(Properties.UPDATE_PROPERTY_EVENTNAME);
+  const UpdateEvent(this._key, this._newValue, this._oldValue)
+      : super(EventType.update);
 
   /// Getter for the updated [key].
   String get key => _key;
 
   /// Getter for the updated [oldValue].
-  String? get oldValue => _oldvalue;
+  String? get oldValue => _oldValue;
 
   /// Getter for the updated [newValue].
-  String? get newValue => _newvalue;
+  String? get newValue => _newValue;
 
   String toString() {
-    return "${Properties.UPDATE_PROPERTY_EVENTNAME} on ${this._key}";
+    return "${EventType.update} on ${this._key}";
   }
 }
 
 /// A factory to create simple property deleted event.
-class DeleteEvent extends PropertiesEvent {
+class DeleteEvent extends ChangeEvent {
   final String _key;
 
   /// Creates a new property deleted event instance by name the [eventType] and the property's [key].
-  const DeleteEvent(this._key) : super(Properties.DELETE_PROPERTY_EVENTNAME);
+  const DeleteEvent(this._key) : super(EventType.delete);
 
   /// Getter for the added [key].
   String get key => _key;
 
   String toString() {
-    return "${Properties.DELETE_PROPERTY_EVENTNAME} on ${this._key}";
+    return "${EventType.delete} on ${this._key}";
   }
 }

--- a/test/properties_test.dart
+++ b/test/properties_test.dart
@@ -10,10 +10,12 @@ void main() {
   String advancedFile = 'resources/sample-adv.properties';
   String saveFile = 'resources/save.properties';
 
-  String jsonSource = '{"key.1" : "value 1", "key.2" : "value 2", "another.key" : "another value"}';
+  String jsonSource =
+      '{"key.1" : "value 1", "key.2" : "value 2", "another.key" : "another value"}';
 
   group('Creation - from properties file', () {
-    test('Existing by path', () => expect(Properties.fromFile(baseFile), isNotNull));
+    test('Existing by path',
+        () => expect(Properties.fromFile(baseFile), isNotNull));
     test('Existing by name', () => expect(Properties(baseFile), isNotNull));
   });
 
@@ -45,7 +47,8 @@ void main() {
   });
 
   group('Creation - from JSON string', () {
-    test('JSON map input', () => expect(Properties.fromJSON(jsonSource), isNotNull));
+    test('JSON map input',
+        () => expect(Properties.fromJSON(jsonSource), isNotNull));
   });
 
   group('Getters - from file source', () {
@@ -53,11 +56,14 @@ void main() {
     setUp(() {
       p = Properties.fromFile(baseFile);
     });
-    test('Existing key - not null', () => expect(p.get('test.key.1'), isNotNull));
-    test('Existing key - equals', () => expect(p.get('test.key.1'), equals('value 1')));
+    test('Existing key - not null',
+        () => expect(p.get('test.key.1'), isNotNull));
+    test('Existing key - equals',
+        () => expect(p.get('test.key.1'), equals('value 1')));
     test('Not existing key', () => expect(p.get('not.existing'), isNull));
 
-    test('Existing key using []', () => expect(p['test.key.1'], equals('value 1')));
+    test('Existing key using []',
+        () => expect(p['test.key.1'], equals('value 1')));
     test('Not existing key using []', () => expect(p['not.existing'], isNull));
 
     test('Get keys', () {
@@ -72,16 +78,27 @@ void main() {
       p = Properties.fromFile(baseFile);
     });
 
-    test('Not existing key - default value', () => expect(p.get('test.key.X', defval: 'value X'), isNotNull));
-    test('Not existing key - default value', () => expect(p.get('test.key.X', defval: 'value X'), equals('value X')));
+    test('Not existing key - default value',
+        () => expect(p.get('test.key.X', defval: 'value X'), isNotNull));
+    test(
+        'Not existing key - default value',
+        () =>
+            expect(p.get('test.key.X', defval: 'value X'), equals('value X')));
 
-    test('Not existing key - default key', () => expect(p.get('test.key.X', defkey: 'test.key.1'), isNotNull));
-    test('Not existing key - default key', () => expect(p.get('test.key.X', defkey: 'test.key.1'), equals('value 1')));
+    test('Not existing key - default key',
+        () => expect(p.get('test.key.X', defkey: 'test.key.1'), isNotNull));
+    test(
+        'Not existing key - default key',
+        () => expect(
+            p.get('test.key.X', defkey: 'test.key.1'), equals('value 1')));
     test('Not existing key - default key, not existing',
         () => expect(p.get('test.key.X', defkey: 'test.key.Y'), isNull));
 
-    test('Not existing key - default value & key',
-        () => expect(p.get('test.key.X', defval: 'value X', defkey: 'test.key.1'), equals('value X')));
+    test(
+        'Not existing key - default value & key',
+        () => expect(
+            p.get('test.key.X', defval: 'value X', defkey: 'test.key.1'),
+            equals('value X')));
   });
 
   group('Getters - from JSON source', () {
@@ -90,8 +107,10 @@ void main() {
       p = Properties.fromJSON(jsonSource);
     });
     test('Existing key - not null', () => expect(p.get('key.1'), isNotNull));
-    test('Existing key - equals', () => expect(p.get('key.1'), equals('value 1')));
-    test('Existing key - equals', () => expect(p.get('another.key'), equals('another value')));
+    test('Existing key - equals',
+        () => expect(p.get('key.1'), equals('value 1')));
+    test('Existing key - equals',
+        () => expect(p.get('another.key'), equals('another value')));
     test('Not existing key', () => expect(p.get('not.existing'), isNull));
     test('Get keys', () {
       Iterable<String> i = p.keys;
@@ -104,11 +123,14 @@ void main() {
     setUp(() {
       p = Properties.fromString(File(baseFile).readAsStringSync());
     });
-    test('Existing key - not null', () => expect(p.get('test.key.1'), isNotNull));
-    test('Existing key - equals', () => expect(p.get('test.key.1'), equals('value 1')));
+    test('Existing key - not null',
+        () => expect(p.get('test.key.1'), isNotNull));
+    test('Existing key - equals',
+        () => expect(p.get('test.key.1'), equals('value 1')));
     test('Not existing key', () => expect(p.get('not.existing'), isNull));
 
-    test('Existing key using []', () => expect(p['test.key.1'], equals('value 1')));
+    test('Existing key using []',
+        () => expect(p['test.key.1'], equals('value 1')));
     test('Not existing key using []', () => expect(p['not.existing'], isNull));
 
     test('Get keys', () {
@@ -123,36 +145,56 @@ void main() {
       p = Properties.fromFile(advancedFile);
     });
 
-    test('Load value with escaped backslash', () => expect(p.get('test.key.slash'), equals(r"C:\\test\\slash")));
+    test('Load value with escaped backslash',
+        () => expect(p.get('test.key.slash'), equals(r"C:\\test\\slash")));
 
-    test('Property with int value existing', () => expect(p.get('test.key.integer'), isNotNull));
-    test('Load int value', () => expect(p.getInt('test.key.integer'), isNotNull));
-    test('Loaded int value parsed successfully', () => expect(p.getInt('test.key.integer'), equals(1)));
+    test('Property with int value existing',
+        () => expect(p.get('test.key.integer'), isNotNull));
+    test('Load int value',
+        () => expect(p.getInt('test.key.integer'), isNotNull));
+    test('Loaded int value parsed successfully',
+        () => expect(p.getInt('test.key.integer'), equals(1)));
 
-    test('Property with double value existing', () => expect(p.get('test.key.double'), isNotNull));
-    test('Load double value', () => expect(p.getDouble('test.key.double'), isNotNull));
-    test('Loaded double value parsed successfully', () => expect(p.getDouble('test.key.double'), equals(2.1)));
+    test('Property with double value existing',
+        () => expect(p.get('test.key.double'), isNotNull));
+    test('Load double value',
+        () => expect(p.getDouble('test.key.double'), isNotNull));
+    test('Loaded double value parsed successfully',
+        () => expect(p.getDouble('test.key.double'), equals(2.1)));
 
-    test('Load a non int value as an int', () => expect(p.getInt('test.key.notinteger'), isNull));
+    test('Load a non int value as an int',
+        () => expect(p.getInt('test.key.notinteger'), isNull));
 
-    test('Load an int with default value', () => expect(p.getInt('test.key.integer.X', defval: 1), equals(1)));
-    test('Load an int with default key',
-        () => expect(p.getInt('test.key.integer.X', defkey: 'test.key.integer'), equals(1)));
+    test('Load an int with default value',
+        () => expect(p.getInt('test.key.integer.X', defval: 1), equals(1)));
+    test(
+        'Load an int with default key',
+        () => expect(p.getInt('test.key.integer.X', defkey: 'test.key.integer'),
+            equals(1)));
 
     test('Load a list', () => expect(p.getList('test.key.list'), isNotNull));
-    test('Load a list', () => expect(p.getList('test.key.list').length, equals(4)));
+    test('Load a list',
+        () => expect(p.getList('test.key.list').length, equals(4)));
 
-    test('Load a multiline property value',
-        () => expect(p.get('test.key.multiline'), equals("this is a multi line property value")));
+    test(
+        'Load a multiline property value',
+        () => expect(p.get('test.key.multiline'),
+            equals("this is a multi line property value")));
 
-    test('Load true bool from true', () => expect(p.getBool('test.key.boolean.true'), equals(true)));
-    test('Load false bool from false', () => expect(p.getBool('test.key.boolean.false'), equals(false)));
+    test('Load true bool from true',
+        () => expect(p.getBool('test.key.boolean.true'), equals(true)));
+    test('Load false bool from false',
+        () => expect(p.getBool('test.key.boolean.false'), equals(false)));
 
-    test('Load true bool from TRUE', () => expect(p.getBool('test.key.boolean.TRUE'), equals(true)));
-    test('Load false bool from FALSE', () => expect(p.getBool('test.key.boolean.FALSE'), equals(false)));
+    test('Load true bool from TRUE',
+        () => expect(p.getBool('test.key.boolean.TRUE'), equals(true)));
+    test('Load false bool from FALSE',
+        () => expect(p.getBool('test.key.boolean.FALSE'), equals(false)));
 
-    test('Load true bool from 1', () => expect(p.getBool('test.key.boolean.1'), equals(true)));
-    test('Load false bool from 0', () => expect(p.getBool('test.key.boolean.0'), equals(false)));
+    test('Load true bool from 1',
+        () => expect(p.getBool('test.key.boolean.1'), equals(true)));
+    test('Load false bool from 0',
+        () => expect(p.getBool('test.key.boolean.0'), equals(false)));
 
     test('Custom bool evaluator', () {
       BoolEvaluator myBE = MyBoolEvaluator();
@@ -198,7 +240,11 @@ void main() {
     });
 
     test('Add a property from Map', () {
-      var map = {'first': 'partridge', 'second': 'turtledoves', 'fifth': 'golden rings'};
+      var map = {
+        'first': 'partridge',
+        'second': 'turtledoves',
+        'fifth': 'golden rings'
+      };
       p.mergeMap(map);
       expect(p.get('second'), equals('turtledoves'));
       expect(p.get('test.key.1'), equals('value 1'));
@@ -242,15 +288,15 @@ void main() {
     test('Add a property and listen to the event', () async {
       p.onAdd.listen(
         expectAsync1((AddEvent e) {
-          expect(e.type, equals(Properties.ADD_PROPERTY_EVENTNAME));
+          expect(e.type, equals(EventType.add));
           expect(e.key, equals("test.key.3"));
           expect(e.value, equals("value 3"));
         }),
       );
       p.onChange.listen(
-        expectAsync1((PropertiesEvent pe) {
+        expectAsync1((ChangeEvent pe) {
           final e = pe as AddEvent;
-          expect(e.type, equals(Properties.ADD_PROPERTY_EVENTNAME));
+          expect(e.type, equals(EventType.add));
           expect(e.key, equals("test.key.3"));
           expect(e.value, equals("value 3"));
         }),
@@ -264,14 +310,14 @@ void main() {
 
     test('Update a property and listen to the event', () {
       p.onUpdate.listen(expectAsync1((e) {
-        expect(e.type, equals(Properties.UPDATE_PROPERTY_EVENTNAME));
+        expect(e.type, equals(EventType.update));
         expect(e.key, equals("test.key.1"));
         expect(e.oldValue, equals("value 1"));
         expect(e.newValue, equals("value new 1"));
       }));
       p.onChange.listen(expectAsync1((pe) {
         final e = pe as UpdateEvent;
-        expect(e.type, equals(Properties.UPDATE_PROPERTY_EVENTNAME));
+        expect(e.type, equals(EventType.update));
         expect(e.key, equals("test.key.1"));
         expect(e.oldValue, equals("value 1"));
         expect(e.newValue, equals("value new 1"));
@@ -286,7 +332,7 @@ void main() {
     test('Delete a property and listen to the event', () {
       p.onChange.listen(expectAsync1((pe) {
         final e = pe as DeleteEvent;
-        expect(e.type, equals(Properties.DELETE_PROPERTY_EVENTNAME));
+        expect(e.type, equals(EventType.delete));
         expect(e.key, equals("test.key.1"));
       }));
 
@@ -299,7 +345,7 @@ void main() {
       // ignore: deprecated_member_use_from_same_package
       p.enableEvents = false;
 
-      String eventType = '';
+      EventType? eventType = null;
       String key = '';
       String value = '';
 
@@ -313,7 +359,7 @@ void main() {
 
       expect(singleAdd, isTrue);
       expect(p.get('test.key.3'), equals('value 3'));
-      expect(eventType, '');
+      expect(eventType, null);
       expect(key, '');
       expect(value, '');
     });
@@ -324,11 +370,20 @@ void main() {
     setUp(() {
       p = Properties.fromFile(baseFile);
     });
-    test('To JSON',
-        () => expect(p.toJSON(), '{"test.key.1":"value 1","test.key.2":"value 2","another.key":"another value"}'));
-    test('To JSON - prefix', () => expect(p.toJSON(prefix: "test"), '{"test.key.1":"value 1","test.key.2":"value 2"}'));
-    test('To JSON - suffix', () => expect(p.toJSON(suffix: "1"), '{"test.key.1":"value 1"}'));
-    test('To JSON - prefix & suffix', () => expect(p.toJSON(prefix: "test", suffix: "2"), '{"test.key.2":"value 2"}'));
+    test(
+        'To JSON',
+        () => expect(p.toJSON(),
+            '{"test.key.1":"value 1","test.key.2":"value 2","another.key":"another value"}'));
+    test(
+        'To JSON - prefix',
+        () => expect(p.toJSON(prefix: "test"),
+            '{"test.key.1":"value 1","test.key.2":"value 2"}'));
+    test('To JSON - suffix',
+        () => expect(p.toJSON(suffix: "1"), '{"test.key.1":"value 1"}'));
+    test(
+        'To JSON - prefix & suffix',
+        () => expect(
+            p.toJSON(prefix: "test", suffix: "2"), '{"test.key.2":"value 2"}'));
   });
 
   group('Merge', () {
@@ -337,7 +392,10 @@ void main() {
       p = Properties.fromFile(baseFile);
     });
     test('Add brand new keys from map', () {
-      p.mergeMap({"test.key.merge1": "merge value 1", "test.key.merge2": "merge value 2"});
+      p.mergeMap({
+        "test.key.merge1": "merge value 1",
+        "test.key.merge2": "merge value 2"
+      });
 
       expect(p.size, equals(5));
       expect(p.get("test.key.merge1"), isNotNull);
@@ -367,15 +425,19 @@ void main() {
       p = Properties.fromFile(baseFile);
     });
     test('Contains - matching', () => expect(p.contains('test.key.2'), isTrue));
-    test('Contains - not matching', () => expect(p.contains('test.key.3'), isFalse));
-    test('Every key - matching', () => expect(p.every((s) => s.startsWith('test')), isNotNull));
-    test('Every key - matching', () => expect(p.every((s) => s.startsWith('test')), isNotEmpty));
+    test('Contains - not matching',
+        () => expect(p.contains('test.key.3'), isFalse));
+    test('Every key - matching',
+        () => expect(p.every((s) => s.startsWith('test')), isNotNull));
+    test('Every key - matching',
+        () => expect(p.every((s) => s.startsWith('test')), isNotEmpty));
     test('Every key - not matching', () {
       Properties? result = p.every((s) => s.startsWith('toast'));
       expect(result, isNull);
     });
     test('Every key & value - matching', () {
-      Properties? m = p.every((s) => s.startsWith('test'), (v) => v == "value 1");
+      Properties? m =
+          p.every((s) => s.startsWith('test'), (v) => v == "value 1");
 
       expect(m, isNot(isEmpty));
       expect(m!.size, equals(1));


### PR DESCRIPTION
Following up on some of my suggestions (plus some basic renaming).

Please note that the previous PR introduced some unwanted formatting (mostly in the test source file), namely 120 chars/line instead of original 80, which you seem to have missed. I find 80 ch/line too limiting and use 120 for my own projects; I forgot to change it then, but it's corrected now. Apologies.

Not sure how to modify the changelog before actually creating a PR, since it needs the PR reference. If you don't have any objections and willing to modify the changelog yourself, please merge, else let me know. Thanks!