### PR TITLE
Remove whitespace around list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Remove whitespace around list items ([#13](https://github.com/vaind/properties.dart/pull/13))
+
 ## 2.1.1
 
 * Move the dependency on `test` package to `dev_dependencies` ([#10](https://github.com/vaind/properties.dart/pull/10))

--- a/lib/properties.dart
+++ b/lib/properties.dart
@@ -257,7 +257,7 @@ class Properties {
       return [];
     }
 
-    return value.split(",");
+    return value.split(",").map((String listItem) => listItem.trim()).toList();
   }
 
   /// Check whether the properties contains a property given its [key]

--- a/test/properties_test.dart
+++ b/test/properties_test.dart
@@ -141,8 +141,10 @@ void main() {
 
     test('Load a list', () => expect(p.getList('test.key.list'), isNotNull));
     test('Load a list', () => expect(p.getList('test.key.list').length, equals(4)));
-    test('Check first value from list', () => expect(p.getList('test.key.list')[0], equals('this')));
-    test('Check second value from list', () => expect(p.getList('test.key.list')[1], equals('is')));
+    test('First list item should have whitespace trimmed',
+        () => expect(p.getList('test.key.list')[0], equals('this')));
+    test('Second list item should have whitespace trimmed',
+        () => expect(p.getList('test.key.list')[1], equals('is')));
 
     test('Load a multiline property value',
         () => expect(p.get('test.key.multiline'), equals("this is a multi line property value")));

--- a/test/properties_test.dart
+++ b/test/properties_test.dart
@@ -141,6 +141,8 @@ void main() {
 
     test('Load a list', () => expect(p.getList('test.key.list'), isNotNull));
     test('Load a list', () => expect(p.getList('test.key.list').length, equals(4)));
+    test('Check first value from list', () => expect(p.getList('test.key.list')[0], equals('this')));
+    test('Check second value from list', () => expect(p.getList('test.key.list')[1], equals('is')));
 
     test('Load a multiline property value',
         () => expect(p.get('test.key.multiline'), equals("this is a multi line property value")));


### PR DESCRIPTION
A suggestion for removing whitespace not only around the list as a whole (as done for single key/values) but also remove it on each item in the list.

I encountered this when using a list like in https://github.com/vaind/properties.dart/blob/main/resources/sample-adv.properties#L12 where each item would contain a space.

Example:
`this, is, a, list`

Before the change it would result in:
`this` ` is` ` a` ` list`

After applying trim():
`this` `is` `a` `list`